### PR TITLE
Change docker image from `tiller-monorepo-circleci` to `tiller-circleci`

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -2,15 +2,15 @@
 description: |
   Uses CircleCI's highly cached convenience images built for CI. Any available tag
   from this list can be used:
-  https://hub.docker.com/r/itinerisltd/tiller-monorepo-circleci/tags
+  https://hub.docker.com/r/itinerisltd/tiller-circleci/tags
 
 parameters:
   tag:
     type: string
     default: base
     description: |
-      Pick a specific itinerisltd/tiller-monorepo-circleci image version tag:
-      https://hub.docker.com/r/itinerisltd/tiller-monorepo-circleci/tags
+      Pick a specific itinerisltd/tiller-circleci image version tag:
+      https://hub.docker.com/r/itinerisltd/tiller-circleci/tags
 
 docker:
-  - image: itinerisltd/tiller-monorepo-circleci:<<parameters.tag>>
+  - image: itinerisltd/tiller-circleci:<<parameters.tag>>

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -35,8 +35,8 @@ parameters:
   executor-tag:
     type: string
     description: |
-      Pick a specific itinerisltd/tiller-monorepo-circleci image version tag:
-      https://hub.docker.com/r/itinerisltd/tiller-monorepo-circleci/tags
+      Pick a specific itinerisltd/tiller-circleci image version tag:
+      https://hub.docker.com/r/itinerisltd/tiller-circleci/tags
     default: base
   setup:
     type: steps


### PR DESCRIPTION
Fix https://discourse.roots.io/t/starting-point-for-deploys-with-circleci/20064/6